### PR TITLE
Fixed the bug in display

### DIFF
--- a/learnbot_simulator/version_2/learnBotDSL.xml
+++ b/learnbot_simulator/version_2/learnBotDSL.xml
@@ -7,6 +7,7 @@
 				<!-- <plane id="axis1y" py="100" nx="1" size="2,200,2" repeat="1" texture="#00ff00" /> -->
 				<!-- <plane id="axis1x" px="100" nx="1" size="2,2,200" repeat="1" texture="#ff0000" /> -->
 				<!-- <plane id="axis1z" pz="100" nx="1" size="200,2,2" repeat="1" texture="#0000ff" /> -->
+			</display>
 		</transform>
 
 		<transform id="view" tx="37.25" ty="-12" tz="200" ry="3.141592650" rx="-0.2">


### PR DESCRIPTION
When we execute learnBotWorldDSL_lines.xml of version 2.0 it gives an error saying as following -

InnerModelReader: reading ./learnBotWorldDSL_lines.xml
InnerModelReader: reading include learnBotDSL.xml
Line 6: <display> is not a valid tag name
Aborted (core dumped)_

I have fixed this problem as closing of display tag was missing in learnBotDSL.xml file.
