### PR TITLE
Updated missing block tooltips for English language

### DIFF
--- a/learnbot_dsl/blocksConfig/basic/Control.conf
+++ b/learnbot_dsl/blocksConfig/basic/Control.conf
@@ -5,7 +5,7 @@
     "name": "main",
     "shape": ["block8"],
     "languages": { "ES": "principal", "EN": "main" },
-    "tooltip": { "ES": "Este bloque se ejecutara cuando los eventos esten desactivados, debera contener el codigo a ejecutar", "EN": ""}
+    "tooltip": { "ES": "Este bloque se ejecutara cuando los eventos esten desactivados, debera contener el codigo a ejecutar", "EN": "This block will be executed when the events are deactivated, it should contain the code to execute"}
 },
 
 
@@ -15,7 +15,7 @@
     "name": "if",
     "shape": ["block6"],
     "languages": { "ES": "si", "EN": "if"},
-    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera. Debe debajo de un bloque si", "EN": ""}
+    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera. Debe debajo de un bloque si", "EN": "It is a control structure that allows a course of action to be redirected on the basis of the given condition, whether it is false or true. The statements under the if block will only be executed if the given condition is True."}
 },
 
 {
@@ -24,7 +24,7 @@
     "name": "elif",
     "shape": ["block6"],
     "languages": { "ES": "sino si", "EN": "else if"},
-    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera. Debe debajo de un bloque si o un bloque sino si", "EN": ""}
+    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera. Debe debajo de un bloque si o un bloque sino si", "EN": "It is a control structure that allows a course of action to be redirected on the basis of the given condition, whether it is false or true. The statements under the else if block will only be executed if the given condition is False."}
 },
 
 {
@@ -33,7 +33,7 @@
     "name": "else",
     "shape": ["block5"],
     "languages": { "ES": "sino", "EN": "else"},
-    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera. Debe debajo de un bloque si o un bloque sino si", "EN": ""}
+    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera. Debe debajo de un bloque si o un bloque sino si", "EN": "It is a control structure that allows a course of action to be redirected on the basis of the given condition, whether it is false or true. The statements under the else if block will only be executed if the given condition is False."}
 },
 
 {
@@ -42,7 +42,7 @@
     "name": "while",
     "shape": ["block6"],
     "languages": { "ES": "mientras", "EN": "while"},
-    "tooltip": { "ES": "Se repetira la secuencia de codigo contenida en el bloque hasta que la condición no se cumpla.", "EN": ""}
+    "tooltip": { "ES": "Se repetira la secuencia de codigo contenida en el bloque hasta que la condición no se cumpla.", "EN": "The code sequence contained in the block will be repeated until the condition is not met."}
 },
 
 {
@@ -51,7 +51,7 @@
     "name": "while True",
     "shape": ["block5"],
     "languages": { "ES": "por siempre", "EN": "forever"},
-    "tooltip": { "ES": "Se repetira la secuencia de codigo contenida en el bloque por siempre.", "EN": ""}
+    "tooltip": { "ES": "Se repetira la secuencia de codigo contenida en el bloque por siempre.", "EN": "The code sequence contained in the block will be repeated forever."}
 },
 
 {
@@ -68,7 +68,7 @@
     ],
     "shape": ["block4", "block3"],
     "languages": { "ES": "tiempo_transcurrido", "EN": "elapsed_Time" },
-    "tooltip": { "ES": "Devuelve verdadero si el tiempo total del programa es mayor o igual que threshold sino devuelve falso", "EN": ""}
+    "tooltip": { "ES": "Devuelve verdadero si el tiempo total del programa es mayor o igual que threshold sino devuelve falso", "EN": "Returns true if the total time of the program is greater than or equal to threshold else returns false"}
 },
 {
     "type" : "others",
@@ -84,6 +84,6 @@
     ],
     "shape" : ["block1"],
     "languages" : {"ES": "esperar", "EN": "wait"},
-    "tooltip" : {"ES": "Espera un tiempo determinado", "EN": ""}
+    "tooltip" : {"ES": "Espera un tiempo determinado", "EN": "Wait for a certain given time."}
 }
 ]

--- a/learnbot_dsl/blocksConfig/basic/Operators.conf
+++ b/learnbot_dsl/blocksConfig/basic/Operators.conf
@@ -4,7 +4,7 @@
     "category" : "operator",
     "name" : "+",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Realiza la operación suma de los bloques conectados", "EN": "Perform the sum operation of the connected blocks"}
+    "tooltip" : {"ES": "Realiza la operación suma de los bloques conectados", "EN": "Perform the add operation of the connected blocks"}
 },
 
 {
@@ -152,4 +152,3 @@
     "tooltip" : {"ES": "(", "EN": "("}
 }
 ]
-

--- a/learnbot_dsl/blocksConfig/basic/Operators.conf
+++ b/learnbot_dsl/blocksConfig/basic/Operators.conf
@@ -4,7 +4,7 @@
     "category" : "operator",
     "name" : "+",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Realiza la operación suma de los bloques conectados", "EN": ""}
+    "tooltip" : {"ES": "Realiza la operación suma de los bloques conectados", "EN": "Perform the sum operation of the connected blocks"}
 },
 
 {
@@ -12,7 +12,7 @@
     "category" : "operator",
     "name" : "-",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Realiza la operación resta de los bloques conectados", "EN": ""}
+    "tooltip" : {"ES": "Realiza la operación resta de los bloques conectados", "EN": "Perform the operation subtract the connected blocks"}
 },
 
 {
@@ -20,7 +20,7 @@
     "category" : "operator",
     "name" : "*",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Realiza la operación multiplicación de los bloques conectados", "EN": ""}
+    "tooltip" : {"ES": "Realiza la operación multiplicación de los bloques conectados", "EN": "Perform the multiplication operation of the connected blocks"}
 },
 
 {
@@ -28,7 +28,7 @@
     "category" : "operator",
     "name" : "/",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Realiza la operación división de los bloques conectados", "EN": ""}
+    "tooltip" : {"ES": "Realiza la operación división de los bloques conectados", "EN": "Perform the division operation of the connected blocks"}
 },
 
 {
@@ -36,42 +36,42 @@
     "category" : "operator",
     "name" : "=",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Iguala el bloque de la izquierda al bloque de la derecha", "EN": ""}
+    "tooltip" : {"ES": "Iguala el bloque de la izquierda al bloque de la derecha", "EN": "Match the block on the left to the block on the right"}
 },
 {
     "type" : "operator",
     "category" : "operator",
     "name" : "==",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Compara los bloques conectados retornando verdadero en caso de que sean iguales y falso en caso contrario", "EN": ""}
+    "tooltip" : {"ES": "Compara los bloques conectados retornando verdadero en caso de que sean iguales y falso en caso contrario", "EN": "Compare the connected blocks returning true if they are equal and false otherwise"}
 },
 {
     "type" : "operator",
     "category" : "operator",
     "name" : "+=",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Operador de adicción a una variable, previamente inicializada", "EN": ""}
+    "tooltip" : {"ES": "Operador de adicción a una variable, previamente inicializada", "EN": "Addition to a variable, previously initialized"}
 },
 {
     "type" : "operator",
     "category" : "operator",
     "name" : "-=",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Operador de resta a una variable, previamente inicializada", "EN": ""}
+    "tooltip" : {"ES": "Operador de resta a una variable, previamente inicializada", "EN": "Subtraction to a variable, previously initialized"}
 },
 {
     "type" : "operator",
     "category" : "operator",
     "name" : "/=",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Operador de división a una variable, previamente inicializada", "EN": ""}
+    "tooltip" : {"ES": "Operador de división a una variable, previamente inicializada", "EN": "Division to a variable, previously initialized"}
 },
 {
     "type" : "operator",
     "category" : "operator",
     "name" : "*=",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Operador de multiplicación a una variable, previamente inicializada", "EN": ""}
+    "tooltip" : {"ES": "Operador de multiplicación a una variable, previamente inicializada", "EN": "Multiplication to a variable, previously initialized"}
 },
 {
     "type" : "operator",
@@ -96,7 +96,7 @@
     "category" : "operator",
     "name" : "<",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Compara los bloques conectados retornando verdadero en caso de que menor el de la derecha y falso en caso contrario.", "EN": ""}
+    "tooltip" : {"ES": "Compara los bloques conectados retornando verdadero en caso de que menor el de la derecha y falso en caso contrario.", "EN": "Compare the connected blocks, returning true if less than the one on the right and false otherwise."}
 },
 
 {
@@ -104,7 +104,7 @@
     "category" : "operator",
     "name" : ">",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Compara los bloques conectados retornando verdadero en caso de que sea menor el de la derecha y falso en caso contrario.", "EN": ""}
+    "tooltip" : {"ES": "Compara los bloques conectados retornando verdadero en caso de que sea menor el de la derecha y falso en caso contrario.", "EN": "Compare the connected blocks returning true if the one on the right is less and false otherwise."}
 },
 
 {
@@ -113,7 +113,7 @@
     "name" : "and",
     "shape" : ["block3"],
     "languages" : {"ES": "Y", "EN": "and"},
-    "tooltip" : {"ES": "Concatena operaciones con la operación lógica Y", "EN": ""}
+    "tooltip" : {"ES": "Concatena operaciones con la operación lógica Y", "EN": "Concatenate operations with logical operation AND"}
 },
 
 {
@@ -122,7 +122,7 @@
     "name" : "or",
     "shape" : ["block3"],
     "languages" : {"ES": "O", "EN": "or"},
-    "tooltip" : {"ES": "Concatena operaciones con la operación lógica O", "EN": ""}
+    "tooltip" : {"ES": "Concatena operaciones con la operación lógica O", "EN": "Concatenate operations with logical operation OR"}
 },
 
 {
@@ -131,7 +131,7 @@
     "name" : "not",
     "shape" : ["block3"],
     "languages" : {"ES": "No", "EN": "not"},
-    "tooltip" : {"ES": "Niega una comparación", "EN": ""}
+    "tooltip" : {"ES": "Niega una comparación", "EN": "Deny a comparison"}
 },
 
 {
@@ -140,7 +140,7 @@
     "name" : ")",
     "shape" : ["block3"],
     "languages" : {"ES": ")", "EN": ")"},
-    "tooltip" : {"ES": ")", "EN": ""}
+    "tooltip" : {"ES": ")", "EN": ")"}
 },
 
 {
@@ -149,7 +149,7 @@
     "name" : "(",
     "shape" : ["block3"],
     "languages" : {"ES": "(", "EN": "("},
-    "tooltip" : {"ES": "(", "EN": ""}
+    "tooltip" : {"ES": "(", "EN": "("}
 }
 ]
 

--- a/learnbot_dsl/blocksConfig/basic/Operators.conf
+++ b/learnbot_dsl/blocksConfig/basic/Operators.conf
@@ -36,7 +36,7 @@
     "category" : "operator",
     "name" : "=",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Iguala el bloque de la izquierda al bloque de la derecha", "EN": "Match the block on the left to the block on the right"}
+    "tooltip" : {"ES": "Iguala el bloque de la izquierda al bloque de la derecha", "EN": "Assign the block on the left to the block on the right"}
 },
 {
     "type" : "operator",

--- a/learnbot_dsl/blocksConfig/basic/Operators.conf
+++ b/learnbot_dsl/blocksConfig/basic/Operators.conf
@@ -12,7 +12,7 @@
     "category" : "operator",
     "name" : "-",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Realiza la operación resta de los bloques conectados", "EN": "Perform the operation subtract the connected blocks"}
+    "tooltip" : {"ES": "Realiza la operación resta de los bloques conectados", "EN": "Perform the subtract operation of the connected blocks"}
 },
 
 {

--- a/learnbot_dsl/blocksConfig/basic/Operators.conf
+++ b/learnbot_dsl/blocksConfig/basic/Operators.conf
@@ -131,7 +131,7 @@
     "name" : "not",
     "shape" : ["block3"],
     "languages" : {"ES": "No", "EN": "not"},
-    "tooltip" : {"ES": "Niega una comparación", "EN": "Deny a comparison"}
+    "tooltip" : {"ES": "Niega una comparación", "EN": "Not operation of the conected block/blocks"}
 },
 
 {

--- a/learnbot_dsl/blocksConfig/default/Motor.conf
+++ b/learnbot_dsl/blocksConfig/default/Motor.conf
@@ -96,7 +96,7 @@
         },
         "tooltip": {
             "ES": "Para el robot",
-            "EN": "For the robot"
+            "EN": "Stop the robot"
         }
     },
     {

--- a/learnbot_dsl/blocksConfig/default/Motor.conf
+++ b/learnbot_dsl/blocksConfig/default/Motor.conf
@@ -80,7 +80,7 @@
         },
         "tooltip": {
             "ES": "Mueve el robot con la velocida de avance y la rotacion indicada",
-            "EN": "Move the robot with the speed of advance and the indicated rotation"
+            "EN": "Move the robot with the specified translation and rotation speed"
         }
     },
     {

--- a/learnbot_dsl/blocksConfig/default/Motor.conf
+++ b/learnbot_dsl/blocksConfig/default/Motor.conf
@@ -12,7 +12,7 @@
         },
         "tooltip": {
             "ES": "Mueve el robot a la izquierda",
-            "EN": ""
+            "EN": "Move the robot to the left"
         }
     },
     {
@@ -28,7 +28,7 @@
         },
         "tooltip": {
             "ES": "Mueve el robot a la derecha",
-            "EN": ""
+            "EN": "Move the robot to the right"
         }
     },
     {
@@ -44,7 +44,7 @@
         },
         "tooltip": {
             "ES": "Mueve el robot a la recto",
-            "EN": ""
+            "EN": "Move the robot straight"
         }
     },
     {
@@ -80,7 +80,7 @@
         },
         "tooltip": {
             "ES": "Mueve el robot con la velocida de avance y la rotacion indicada",
-            "EN": ""
+            "EN": "Move the robot with the speed of advance and the indicated rotation"
         }
     },
     {
@@ -96,7 +96,7 @@
         },
         "tooltip": {
             "ES": "Para el robot",
-            "EN": ""
+            "EN": "For the robot"
         }
     },
     {
@@ -112,7 +112,7 @@
         },
         "tooltip": {
             "ES": "Establece la orientaci\u00f3n actual a 0\u00ba",
-            "EN": ""
+            "EN": "Resets the orientation to its orignal state"
         }
     },
     {
@@ -139,7 +139,7 @@
         },
         "tooltip": {
             "ES": "Sit\u00faa la base del robot en una cierta orientaci\u00f3n",
-            "EN": ""
+            "EN": "Set the base of the orientation to a specific value"
         }
     },
     {
@@ -166,7 +166,7 @@
         },
         "tooltip": {
             "ES": "Gira el robot con una velocidad angular",
-            "EN": ""
+            "EN": "Rotate the robot with an angular speed"
         }
     },
     {
@@ -182,7 +182,7 @@
         },
         "tooltip": {
             "ES": "Gira el robot hacia atras",
-            "EN": ""
+            "EN": "Turn the robot back"
         }
     },
     {
@@ -198,7 +198,7 @@
         },
         "tooltip": {
             "ES": "Gira al robot a la izquierda",
-            "EN": ""
+            "EN": "Turn the robot to the left"
         }
     },
     {
@@ -214,7 +214,7 @@
         },
         "tooltip": {
             "ES": "Gira al robot a la derecha",
-            "EN": ""
+            "EN": "Turn the robot to the right"
         }
     },
     {
@@ -230,7 +230,7 @@
         },
         "tooltip": {
             "ES": "Reduce la velocidad del robot",
-            "EN": ""
+            "EN": "Reduce robot speed"
         }
     },
     {
@@ -246,7 +246,7 @@
         },
         "tooltip": {
             "ES": "Gira la camara del robot para que este mire al suelo",
-            "EN": ""
+            "EN": "Rotate the robot's camera so that it faces the ground"
         }
     },
     {
@@ -262,7 +262,7 @@
         },
         "tooltip": {
             "ES": "Mueve la camara hacia arriba.",
-            "EN": ""
+            "EN": "Move the camera up."
         }
     },
     {
@@ -278,7 +278,7 @@
         },
         "tooltip": {
             "ES": "Mueve la camara hacia el frente",
-            "EN": ""
+            "EN": "Move the camera forward"
         }
     },
     {
@@ -305,7 +305,7 @@
         },
         "tooltip": {
             "ES": "Mueve la camara a un angulo determinado",
-            "EN": ""
+            "EN": "Move the camera to a certain angle"
         }
     },
     {
@@ -341,7 +341,7 @@
         },
         "tooltip": {
             "ES": "Mueve la camara a un angulo determinado",
-            "EN": ""
+            "EN": "Move the camera to a certain angle"
         }
     }
 ]


### PR DESCRIPTION
In the .conf files present inside /learnbot_dsl/blocksConfig , most of the tooltips of various blocks were missing for English. So I updated them