### PR TITLE
Updated missing block tooltips for English language and corrected some incorrect spanish tooltips. 

### DIFF
--- a/learnbot_dsl/blocksConfig/basic/Control.conf
+++ b/learnbot_dsl/blocksConfig/basic/Control.conf
@@ -15,7 +15,7 @@
     "name": "if",
     "shape": ["block6"],
     "languages": { "ES": "si", "EN": "if"},
-    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera. Debe debajo de un bloque si", "EN": "This is a control structure that allows redirecting a course of action according to the evaluation of a condition, whether it is true or false. It must be below a 'if' block."},
+    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera.", "EN": "This is a control structure that allows redirecting a course of action according to the evaluation of a condition, whether it is true or false.},
     "inputs" : ["bool"]
 },
 
@@ -25,7 +25,7 @@
     "name": "elif",
     "shape": ["block6"],
     "languages": { "ES": "sino si", "EN": "else if"},
-    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera. Debe debajo de un bloque si o un bloque sino si", "EN": "This is a control structure that allows redirecting a course of action according to the evaluation of a condition, whether it is true or false. It must be under an 'else if' block."},
+    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera. Debe situarse debajo de un bloque 'si' o un bloque 'sino si'", "EN": "This is a control structure that allows redirecting a course of action according to the evaluation of a condition, whether it is true or false. It must be under an 'if' block or an 'else if' block."},
     "inputs" : ["bool"]
 },
 
@@ -35,7 +35,7 @@
     "name": "else",
     "shape": ["block5"],
     "languages": { "ES": "sino", "EN": "else"},
-    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera. Debe debajo de un bloque si o un bloque sino si", "EN": "This is a control structure that allows redirecting a course of action according to the evaluation of a condition, whether it is true or false. It must be under 'else' block."},
+    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera. Debe situarse debajo de un bloque 'si' o un bloque 'sino si'", "EN": "This is a control structure that allows redirecting a course of action according to the evaluation of a condition, whether it is true or false. It must be under an 'if' block or an 'else if' block."},
     "inputs" : ["bool"]
 },
 
@@ -72,7 +72,7 @@
     ],
     "shape": ["block4", "block3"],
     "languages": { "ES": "tiempo_transcurrido", "EN": "elapsed_Time" },
-    "tooltip": { "ES": "Devuelve verdadero si el tiempo total del programa es mayor o igual que threshold sino devuelve falso", "EN": "Returns true if the total time of the program is greater than or equal to threshold otherwise returns false"}
+    "tooltip": { "ES": "Devuelve verdadero si el tiempo total del programa es mayor o igual que 'threshold', si no devuelve falso", "EN": "Returns true if the total time of the program is greater or equal than 'threshold', otherwise it returns false"}
 },
 {
     "type" : "others",

--- a/learnbot_dsl/blocksConfig/basic/Control.conf
+++ b/learnbot_dsl/blocksConfig/basic/Control.conf
@@ -5,7 +5,7 @@
     "name": "main",
     "shape": ["block8"],
     "languages": { "ES": "principal", "EN": "main" },
-    "tooltip": { "ES": "Este bloque se ejecutara cuando los eventos esten desactivados, debera contener el codigo a ejecutar", "EN": ""}
+    "tooltip": { "ES": "Este bloque se ejecutara cuando los eventos esten desactivados, debera contener el codigo a ejecutar", "EN": "This block will be executed when the events are deactivated, it should contain the code to execute"}
 },
 
 
@@ -15,7 +15,7 @@
     "name": "if",
     "shape": ["block6"],
     "languages": { "ES": "si", "EN": "if"},
-    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera. Debe debajo de un bloque si", "EN": ""},
+    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera. Debe debajo de un bloque si", "EN": "This is a control structure that allows redirecting a course of action according to the evaluation of a condition, whether it is true or false. It must be below a 'if' block."},
     "inputs" : ["bool"]
 },
 
@@ -25,7 +25,7 @@
     "name": "elif",
     "shape": ["block6"],
     "languages": { "ES": "sino si", "EN": "else if"},
-    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera. Debe debajo de un bloque si o un bloque sino si", "EN": ""},
+    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera. Debe debajo de un bloque si o un bloque sino si", "EN": "This is a control structure that allows redirecting a course of action according to the evaluation of a condition, whether it is true or false. It must be under an 'else if' block."},
     "inputs" : ["bool"]
 },
 
@@ -35,7 +35,7 @@
     "name": "else",
     "shape": ["block5"],
     "languages": { "ES": "sino", "EN": "else"},
-    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera. Debe debajo de un bloque si o un bloque sino si", "EN": ""},
+    "tooltip": { "ES": "Se trata de una estructura de control que permite redirigir un curso de acción segun la evaluación de una condición, sea falsa o verdadera. Debe debajo de un bloque si o un bloque sino si", "EN": "This is a control structure that allows redirecting a course of action according to the evaluation of a condition, whether it is true or false. It must be under 'else' block."},
     "inputs" : ["bool"]
 },
 
@@ -45,7 +45,7 @@
     "name": "while",
     "shape": ["block6"],
     "languages": { "ES": "mientras", "EN": "while"},
-    "tooltip": { "ES": "Se repetira la secuencia de codigo contenida en el bloque hasta que la condición no se cumpla.", "EN": ""},
+    "tooltip": { "ES": "Se repetira la secuencia de codigo contenida en el bloque hasta que la condición no se cumpla.", "EN": "The code sequence contained in the block will be repeated until the condition is not met."},
     "inputs" : ["bool"]
 },
 
@@ -55,7 +55,7 @@
     "name": "while True",
     "shape": ["block5"],
     "languages": { "ES": "por siempre", "EN": "forever"},
-    "tooltip": { "ES": "Se repetira la secuencia de codigo contenida en el bloque por siempre.", "EN": ""}
+    "tooltip": { "ES": "Se repetira la secuencia de codigo contenida en el bloque por siempre.", "EN": "The code sequence contained in the block will be repeated forever."}
 },
 
 {
@@ -72,7 +72,7 @@
     ],
     "shape": ["block4", "block3"],
     "languages": { "ES": "tiempo_transcurrido", "EN": "elapsed_Time" },
-    "tooltip": { "ES": "Devuelve verdadero si el tiempo total del programa es mayor o igual que threshold sino devuelve falso", "EN": ""}
+    "tooltip": { "ES": "Devuelve verdadero si el tiempo total del programa es mayor o igual que threshold sino devuelve falso", "EN": "Returns true if the total time of the program is greater than or equal to threshold otherwise returns false"}
 },
 {
     "type" : "others",
@@ -88,6 +88,6 @@
     ],
     "shape" : ["block1"],
     "languages" : {"ES": "esperar", "EN": "wait"},
-    "tooltip" : {"ES": "Espera un tiempo determinado", "EN": ""}
+    "tooltip" : {"ES": "Espera un tiempo determinado", "EN": "Wait for a certain period of time"}
 }
 ]

--- a/learnbot_dsl/blocksConfig/basic/Operators.conf
+++ b/learnbot_dsl/blocksConfig/basic/Operators.conf
@@ -44,14 +44,14 @@
     "category" : "operator",
     "name" : "=",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Iguala el bloque de la izquierda al bloque de la derecha", "EN": "Equalizes the left block to the right block."}
+    "tooltip" : {"ES": "Asigna el bloque de la izquierda al bloque de la derecha", "EN": "Assigns the left block to the right block."}
 },
 {
     "type" : "operator",
     "category" : "operator",
     "name" : "==",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Compara los bloques conectados retornando verdadero en caso de que sean iguales y falso en caso contrario", "EN": "Compares the connected blocks, returning true if they are equal and false if not."},
+    "tooltip" : {"ES": "Compara los bloques conectados retornando verdadero en caso de que sean iguales y falso en caso contrario", "EN": "Compares the connected blocks, returning true if they are equal and false otherwise."},
     "inputs" : ["bool", "bool"],
     "output" : "bool"
 },
@@ -60,28 +60,28 @@
     "category" : "operator",
     "name" : "+=",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Operador de adicción a una variable, previamente inicializada", "EN": "Operator of addition to a variable, previously initialized."}
+    "tooltip" : {"ES": "Operador de adicción a una variable previamente inicializada", "EN": "Operator of addition to a previously initialized variable."}
 },
 {
     "type" : "operator",
     "category" : "operator",
     "name" : "-=",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Operador de resta a una variable, previamente inicializada", "EN": "subtraction operator to a variable, previously initialized"}
+    "tooltip" : {"ES": "Operador de resta a una variable previamente inicializada", "EN": "subtraction operator to a previously initialized variable"}
 },
 {
     "type" : "operator",
     "category" : "operator",
     "name" : "/=",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Operador de división a una variable, previamente inicializada", "EN": "Operator of division to a variable, previously initialized."}
+    "tooltip" : {"ES": "Operador de división a una variable previamente inicializada", "EN": "Operator of division to a  previously initialized variable."}
 },
 {
     "type" : "operator",
     "category" : "operator",
     "name" : "*=",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Operador de multiplicación a una variable, previamente inicializada", "EN": "Multiplication operator to a variable, previously initialized."}
+    "tooltip" : {"ES": "Operador de multiplicación a una variable previamente inicializada", "EN": "Multiplication operator to a  previously initialized variable."}
 },
 {
     "type" : "operator",
@@ -151,7 +151,7 @@
     "name" : "not",
     "shape" : ["block3"],
     "languages" : {"ES": "No", "EN": "not"},
-    "tooltip" : {"ES": "Niega una comparación", "EN": "Denies a comparison"},
+    "tooltip" : {"ES": "Transforma un valor de 'cierto' en 'falso' y viceversa", "EN": "Invert a logical result (true to false and vice versa."},
     "inputs" : ["bool"],
     "output" : "bool"
 },

--- a/learnbot_dsl/blocksConfig/basic/Operators.conf
+++ b/learnbot_dsl/blocksConfig/basic/Operators.conf
@@ -4,7 +4,7 @@
     "category" : "operator",
     "name" : "+",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Realiza la operación suma de los bloques conectados", "EN": ""},
+    "tooltip" : {"ES": "Realiza la operación suma de los bloques conectados", "EN": "Performs the sum operation of the connected blocks"},
     "inputs" : ["number", "number"],
     "output" : "number"
 },
@@ -14,7 +14,7 @@
     "category" : "operator",
     "name" : "-",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Realiza la operación resta de los bloques conectados", "EN": ""},
+    "tooltip" : {"ES": "Realiza la operación resta de los bloques conectados", "EN": "Performs the subtraction operation of the connected blocks"},
     "inputs" : ["number", "number"],
     "output" : "number"
 },
@@ -24,7 +24,7 @@
     "category" : "operator",
     "name" : "*",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Realiza la operación multiplicación de los bloques conectados", "EN": ""},
+    "tooltip" : {"ES": "Realiza la operación multiplicación de los bloques conectados", "EN": "Performs the multiplication operation of the connected blocks"},
     "inputs" : ["number", "number"],
     "output" : "number"
 },
@@ -34,7 +34,7 @@
     "category" : "operator",
     "name" : "/",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Realiza la operación división de los bloques conectados", "EN": ""},
+    "tooltip" : {"ES": "Realiza la operación división de los bloques conectados", "EN": "Performs the division operation of the connected blocks"},
     "inputs" : ["number", "number"],
     "output" : "number"
 },
@@ -44,14 +44,14 @@
     "category" : "operator",
     "name" : "=",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Iguala el bloque de la izquierda al bloque de la derecha", "EN": ""}
+    "tooltip" : {"ES": "Iguala el bloque de la izquierda al bloque de la derecha", "EN": "Equalizes the left block to the right block."}
 },
 {
     "type" : "operator",
     "category" : "operator",
     "name" : "==",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Compara los bloques conectados retornando verdadero en caso de que sean iguales y falso en caso contrario", "EN": ""},
+    "tooltip" : {"ES": "Compara los bloques conectados retornando verdadero en caso de que sean iguales y falso en caso contrario", "EN": "Compares the connected blocks, returning true if they are equal and false if not."},
     "inputs" : ["bool", "bool"],
     "output" : "bool"
 },
@@ -60,28 +60,28 @@
     "category" : "operator",
     "name" : "+=",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Operador de adicción a una variable, previamente inicializada", "EN": ""}
+    "tooltip" : {"ES": "Operador de adicción a una variable, previamente inicializada", "EN": "Operator of addition to a variable, previously initialized."}
 },
 {
     "type" : "operator",
     "category" : "operator",
     "name" : "-=",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Operador de resta a una variable, previamente inicializada", "EN": ""}
+    "tooltip" : {"ES": "Operador de resta a una variable, previamente inicializada", "EN": "subtraction operator to a variable, previously initialized"}
 },
 {
     "type" : "operator",
     "category" : "operator",
     "name" : "/=",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Operador de división a una variable, previamente inicializada", "EN": ""}
+    "tooltip" : {"ES": "Operador de división a una variable, previamente inicializada", "EN": "Operator of division to a variable, previously initialized."}
 },
 {
     "type" : "operator",
     "category" : "operator",
     "name" : "*=",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Operador de multiplicación a una variable, previamente inicializada", "EN": ""}
+    "tooltip" : {"ES": "Operador de multiplicación a una variable, previamente inicializada", "EN": "Multiplication operator to a variable, previously initialized."}
 },
 {
     "type" : "operator",
@@ -108,7 +108,7 @@
     "category" : "operator",
     "name" : "<",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Compara los bloques conectados retornando verdadero en caso de que menor el de la derecha y falso en caso contrario.", "EN": ""},
+    "tooltip" : {"ES": "Compara los bloques conectados devolviendo verdadero si el de la derecha es mayor y falso en caso contrario", "EN": "Compares the connected blocks, returning true if the one on the right is greater and false otherwise"},
     "inputs" : ["bool", "bool"],
     "output" : "bool"
 },
@@ -118,7 +118,7 @@
     "category" : "operator",
     "name" : ">",
     "shape" : ["block3"],
-    "tooltip" : {"ES": "Compara los bloques conectados retornando verdadero en caso de que sea menor el de la derecha y falso en caso contrario.", "EN": ""},
+    "tooltip" : {"ES": "Compara los bloques conectados retornando verdadero en caso de que menor el de la derecha y falso en caso contrario", "EN": "It compares the connected blocks returning true if the one on the right is smaller and false otherwise."},
     "inputs" : ["bool", "bool"],
     "output" : "bool"
 },
@@ -129,7 +129,7 @@
     "name" : "and",
     "shape" : ["block3"],
     "languages" : {"ES": "Y", "EN": "and"},
-    "tooltip" : {"ES": "Concatena operaciones con la operación lógica Y", "EN": ""},
+    "tooltip" : {"ES": "Concatena operaciones con la operación lógica Y", "EN": "Concatenates operations with the logical AND operation"},
     "inputs" : ["bool", "bool"],
     "output" : "bool"
 },
@@ -140,7 +140,7 @@
     "name" : "or",
     "shape" : ["block3"],
     "languages" : {"ES": "O", "EN": "or"},
-    "tooltip" : {"ES": "Concatena operaciones con la operación lógica O", "EN": ""},
+    "tooltip" : {"ES": "Concatena operaciones con la operación lógica O", "EN": "Concatenates operations with the logical operation OR"},
     "inputs" : ["bool", "bool"],
     "output" : "bool"
 },
@@ -151,7 +151,7 @@
     "name" : "not",
     "shape" : ["block3"],
     "languages" : {"ES": "No", "EN": "not"},
-    "tooltip" : {"ES": "Niega una comparación", "EN": ""},
+    "tooltip" : {"ES": "Niega una comparación", "EN": "Denies a comparison"},
     "inputs" : ["bool"],
     "output" : "bool"
 },
@@ -174,4 +174,3 @@
     "tooltip" : {"ES": "(", "EN": ""}
 }
 ]
-


### PR DESCRIPTION
* In the Control.conf file present inside /learnbot_dsl/block config/basic, updated missing block tooltips in 'EN' .
* In the Operators.conf file present inside /learnbot_dsl/block config/basic, updated missing block tooltips in 'EN' .
* In the Operators.conf file corrected Spanish tooltip for '<' operator.